### PR TITLE
Fix incorrect block states

### DIFF
--- a/anvil/empty_section.py
+++ b/anvil/empty_section.py
@@ -127,10 +127,9 @@ class EmptySection:
             # If it's more than 64 bits then add to list and start over
             # with the remaining bits from last one
             if current_len + bits > 64:
-                leftover = 64 - current_len
-                states.append(bin_append(index & ((1 << leftover) - 1), current, length=current_len))
-                current = index >> leftover
-                current_len = bits - leftover
+                states.append(current)
+                current = index
+                current_len = bits
             else:
                 current = bin_append(index, current, length=current_len)
                 current_len += bits


### PR DESCRIPTION
1.16 changes how block states work, and this module uses the old behavior

Because the world is marked as created in 1.16, Minecraft does not convert it, leaving chunk sections with >16 unique blocks either broken or corrupted